### PR TITLE
fix testsuite against QuickCheck-2.8.2

### DIFF
--- a/tests/DBusTests/Util.hs
+++ b/tests/DBusTests/Util.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TemplateHaskell, CPP #-}
 
 -- Copyright (C) 2010-2012 John Millikin <john@john-millikin.com>
 --
@@ -192,8 +192,10 @@ countFileDescriptors = liftIO io where
 				then return n
 				else loop (n + 1)
 
+#if ! MIN_VERSION_QuickCheck(2,8,2)
 instance (Arbitrary a, Ord a) => Arbitrary (Data.Set.Set a) where
 	arbitrary = fmap Data.Set.fromList arbitrary
+#endif
 
 halfSized :: Gen a -> Gen a
 halfSized gen = sized (\n -> if n > 0


### PR DESCRIPTION
ghc failed as:
  [10 of 27] Compiling DBusTests.Util   ( tests/DBusTests/Util.hs, dist/build/dbus_tests/dbus_tests-tmp/DBusTests/Util.dyn_o )

  tests/DBusTests/Util.hs:195:10:
    Duplicate instance declarations:
      instance (Arbitrary a, Ord a) => Arbitrary (Data.Set.Set a)
        -- Defined at tests/DBusTests/Util.hs:195:10
      instance [safe](Ord a, Arbitrary a) => Arbitrary (Data.Set.Set a)
        -- Defined in ‘Test.QuickCheck.Arbitrary’

QuickCheck added these instances in:
    https://github.com/nick8325/quickcheck/commit/ce6e6374c4c6c6cb40315f661f0abf4e60ecfbf3

Signed-off-by: Sergei Trofimovich siarheit@google.com
