### PR TITLE
getSessionAddress: take first bus address from list

### DIFF
--- a/lib/DBus/Address.hs
+++ b/lib/DBus/Address.hs
@@ -18,6 +18,7 @@ module DBus.Address where
 import qualified Control.Exception
 import           Data.Char (digitToInt, ord, chr)
 import           Data.List (intercalate)
+import           Data.Maybe (listToMaybe)
 import qualified Data.Map
 import           Data.Map (Map)
 import qualified System.Environment
@@ -152,7 +153,7 @@ getSystemAddress = do
 getSessionAddress :: IO (Maybe Address)
 getSessionAddress = do
 	env <- getenv "DBUS_SESSION_BUS_ADDRESS"
-	return (env >>= parseAddress)
+	return $ maybe Nothing listToMaybe (env >>= parseAddresses)
 
 -- | Returns the address in the environment variable
 -- @DBUS_STARTER_ADDRESS@, which must be set.


### PR DESCRIPTION
This fixes issues with new `DBUS_SESSION_BUS_ADDRESS` format, which may now contain several semicolon-separated addresses.

Notice that this doesn't conflict with https://github.com/jmillikin/haskell-dbus/pull/6, but rather complements it to also fix `getSessionAddress` behaviour.

cc @rvl (possibly interested)